### PR TITLE
ogn.utils: Add get_trackable.

### DIFF
--- a/ogn/utils.py
+++ b/ogn/utils.py
@@ -12,6 +12,10 @@ DDB_URL = "http://ddb.glidernet.org/download"
 deg2rad = pi/180
 rad2deg = 1/deg2rad
 
+address_prefixes = {'F':'FLR',
+                    'O':'OGN',
+                    'I':'ICA'}
+
 
 def get_ddb(csvfile=None):
     if csvfile is None:
@@ -41,6 +45,14 @@ def get_ddb(csvfile=None):
         devices.append(flarm)
 
     return devices
+
+
+def get_trackable(ddb):
+   l = []
+   for i in ddb:
+       if i.tracked and i.address_type in address_prefixes:
+           l.append('{}{}'.format(address_prefixes[i.address_type], i.address))
+   return l
 
 
 def get_country_code(latitude, longitude):

--- a/tests/custom_ddb.txt
+++ b/tests/custom_ddb.txt
@@ -1,4 +1,7 @@
 #DEVICE_TYPE,DEVICE_ID,AIRCRAFT_MODEL,REGISTRATION,CN,TRACKED,IDENTIFIED
 'F','DD4711','HK36 TTC','D-EULE','CU','Y','Y'
-'F','DD0815','Ventus 2cxM','D-1234','','Y','Y'
-'F','DD3141','Arcus T','OE-4321','','Y','Y'
+'F','DD0815','Ventus 2cxM','D-1234','','Y','N'
+'F','DD1234','LS 8 18m','D-8654','12','N','Y'
+'F','DD3141','Arcus T','OE-4321','','N','N'
+'O','DEADBE','Baloon','OE-ABC','','Y','Y'
+'I','999999','A380','G-XXXL','XXL','Y','Y'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ogn.utils import get_ddb, get_country_code, wgs84_to_sphere
+from ogn.utils import get_ddb, get_trackable, get_country_code, wgs84_to_sphere
 from ogn.model import AddressOrigin
 
 
@@ -11,7 +11,7 @@ class TestStringMethods(unittest.TestCase):
 
     def test_get_ddb_from_file(self):
         devices = get_ddb('tests/custom_ddb.txt')
-        self.assertEqual(len(devices), 3)
+        self.assertEqual(len(devices), 6)
         device = devices[0]
 
         self.assertEqual(device.address, 'DD4711')
@@ -22,6 +22,15 @@ class TestStringMethods(unittest.TestCase):
         self.assertTrue(device.identified)
 
         self.assertEqual(device.address_origin, AddressOrigin.userdefined)
+
+    def test_get_trackable(self):
+        devices = get_ddb('tests/custom_ddb.txt')
+        trackable = get_trackable(devices)
+        self.assertEqual(len(trackable), 4)
+        self.assertIn('FLRDD4711', trackable)
+        self.assertIn('FLRDD0815', trackable)
+        self.assertIn('OGNDEADBE', trackable)
+        self.assertIn('ICA999999', trackable)
 
     def test_get_country_code(self):
         latitude = 48.0


### PR DESCRIPTION
The method itself is trivial, but the corresponding array `address_prefixes` should be included in this framework.