### PR TITLE
Add Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ It requires [PostgreSQL](http://www.postgresql.org/) and [PostGIS](http://www.po
     ./manage.py db.init
     ```
 
+There is also a [Vagrant](https://www.vagrantup.com/) environment for the development of ogn-python.
+You can create and start this virtual machine with `vagrant up` and login with `vagrant ssh`.
+The code of ogn-python will be available in the shared folder `/vagrant`.
+
 ## Usage
 ### Running the aprs client and task server
 To schedule tasks like takeoff/landing-detection (`logbook.compute`),

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,35 @@
+$script = <<SCRIPT
+
+set -e
+
+# install PostgreSQL and PostGIS
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends postgresql-9.4-postgis-2.1 libpq-dev
+
+# create PostGIS database
+sudo sudo -u postgres createuser -s vagrant
+
+sudo sudo -u postgres createdb ogn -O vagrant
+sudo sudo -u postgres psql -d ogn -c 'CREATE EXTENSION postgis;'
+
+# install python requirements
+cd /vagrant
+sudo apt-get install -y --no-install-recommends redis-server build-essential python3 python3-pip python3-dev libpq-dev libgeos-dev
+sudo -H pip3 install -r requirements.txt
+
+# # initialize database
+./manage.py db.init
+
+# # import registered devices from ddb
+./manage.py db.import_ddb
+
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = 'debian/jessie64'
+
+  # Current version is broken
+  config.vm.box_version = '8.5.2'
+
+  config.vm.provision 'shell', inline: $script, privileged: false
+end

--- a/config/default.py
+++ b/config/default.py
@@ -1,4 +1,4 @@
-SQLALCHEMY_DATABASE_URI = 'postgresql://postgres@localhost:5432/ogn'
+SQLALCHEMY_DATABASE_URI = 'postgresql:///ogn'
 
 BROKER_URL = 'redis://localhost:6379/0'
 CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'


### PR DESCRIPTION
ogn-python requires a running PostgreSQL and Celery daemon. With [vagrant][1] and [VirtualBox][2] it is possible to create a clean development environment inside a virtual machine.

This commit was greately inspired by [SkyLines][3].

[1]: https://www.vagrantup.com/
[2]: https://www.virtualbox.org/
[3]: https://github.com/skylines-project/skylines